### PR TITLE
docker compose dumbification

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,12 +38,16 @@ DumbWareIO is a collection of self-hosted applications designed for simplicity a
 
   | Variable             | Default                   |
   |----------------------|---------------------------|
-  | DUMB_PORT            | 3000                      |
   | DUMB_PIN             | (nothing)                 |
+  | DUMBBUDGET_PORT      | 3333                      |
   | DUMBBUDGET_DATA_PATH | /opt/dumbsuite/dumbbudget |
+  | DUMBDO_PORT          | 3334                      |
   | DUMBDO_DATA_PATH     | /opt/dumbsuite/dumbdo     |
+  | DUMBDROP_PORT        | 3335                      |
   | DUMBDROP_DATA_PATH   | /opt/dumbsuite/dumbdrop   |
+  | DUMBPAD_PORT         | 3336                      |
   | DUMBPAD_DATA_PATH    | /opt/dumbsuite/dumbpad    |
+  | DUMBKAN_PORT         | 3337                      |
   | DUMBKAN_DATA_PATH    | /opt/dumbsuite/dumbkan    |
 
   - Modify dumbcompose.yml if you want a different pin per dumb app

--- a/README.md
+++ b/README.md
@@ -33,8 +33,8 @@ DumbWareIO is a collection of self-hosted applications designed for simplicity a
    ```
 
 2. **Modify Configuration:**
-   - Create a .env file in the same directory as the compose file, or optionally rename env to .env and use that
-   - Add the following variables if you need to:
+   - This is an entirely optional step, rename env to .env
+   - Modify the following variables in .envx
 
   | Variable             | Default                   |
   |----------------------|---------------------------|
@@ -50,7 +50,7 @@ DumbWareIO is a collection of self-hosted applications designed for simplicity a
   | DUMBKAN_PORT         | 3337                      |
   | DUMBKAN_DATA_PATH    | /opt/dumbsuite/dumbkan    |
 
-  - Modify dumbcompose.yml if you want a different pin per dumb app
+   - Note that this is a very dumb setup. A less dumber setup would remove ports and configure networks for better isolation.
 
 3. **Run the Services:**
    ```sh
@@ -67,6 +67,13 @@ DumbWareIO is a collection of self-hosted applications designed for simplicity a
    docker-compose pull
    docker-compose up -d
    ```
+
+6. **Use the Services:**
+  - DumbBudget can be accessed from http://localhost:3333
+  - DumbDo can be accessed from http://localhost:3334
+  - DumbDrop can be accessed from http://localhost:3335
+  - DumbPad can be accessed from http://localhost:3336
+  - DumbKan can be accessed from http://localhost:3337
 
 ## Troubleshooting
 

--- a/README.md
+++ b/README.md
@@ -33,9 +33,20 @@ DumbWareIO is a collection of self-hosted applications designed for simplicity a
    ```
 
 2. **Modify Configuration:**
-   - Replace `YOUR_PORT_HERE` with the desired ports.
-   - Replace `/path/to/your/...` with actual host paths.
-   - Set any necessary PINs in the `environment` section of `docker-compose.yml`.
+   - Create a .env file in the same directory as the compose file, or optionally rename env to .env and use that
+   - Add the following variables if you need to:
+
+  | Variable             | Default                   |
+  |----------------------|---------------------------|
+  | DUMB_PORT            | 3000                      |
+  | DUMB_PIN             | (nothing)                 |
+  | DUMBBUDGET_DATA_PATH | /opt/dumbsuite/dumbbudget |
+  | DUMBDO_DATA_PATH     | /opt/dumbsuite/dumbdo     |
+  | DUMBDROP_DATA_PATH   | /opt/dumbsuite/dumbdrop   |
+  | DUMBPAD_DATA_PATH    | /opt/dumbsuite/dumbpad    |
+  | DUMBKAN_DATA_PATH    | /opt/dumbsuite/dumbkan    |
+
+  - Modify dumbcompose.yml if you want a different pin per dumb app
 
 3. **Run the Services:**
    ```sh
@@ -66,4 +77,3 @@ DumbWareIO is a collection of self-hosted applications designed for simplicity a
 For more details, visit [DumbWareIO](https://dumbware.io).
 To support our projects, please consider donating at [Buy Me a Coffee](https://buymeacoffee.com/dumbware).
 And as always, join the community at [Discord](https://dumbware.io/discord)!
-

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -12,7 +12,7 @@ services:
     environment:
       - DUMBBUDGET_PIN=${DUMB_PIN:-}
     healthcheck:
-      test: ["CMD-SHELL", "curl --fail http://localhost:${DUMBBUDGET_PORT:-3333} || exit 1"]
+      test: wget --spider -q  http://127.0.0.1:3000
       start_period: 20s
       interval: 20s
       timeout: 5s
@@ -31,7 +31,7 @@ services:
     environment:
       - DUMBDO_PIN=${DUMB_PIN:-}
     healthcheck:
-      test: ["CMD-SHELL", "curl --fail http://localhost:${DUMBDO_PORT:-3333} || exit 1"]
+      test: wget --spider -q  http://127.0.0.1:3000
       start_period: 20s
       interval: 20s
       timeout: 5s
@@ -50,7 +50,7 @@ services:
     environment:
       - DUMBDROP_PIN=${DUMB_PIN:-}
     healthcheck:
-      test: ["CMD-SHELL", "curl --fail http://localhost:${DUMBDROP_PORT:-3333} || exit 1"]
+      test: wget --spider -q  http://127.0.0.1:3000
       start_period: 20s
       interval: 20s
       timeout: 5s
@@ -69,7 +69,7 @@ services:
     environment:
       - DUMBPAD_PIN=${DUMB_PIN:-}
     healthcheck:
-      test: ["CMD-SHELL", "curl --fail http://localhost:${DUMBPAD_PORT:-3333} || exit 1"]
+      test: wget --spider -q  http://127.0.0.1:3000
       start_period: 20s
       interval: 20s
       timeout: 5s
@@ -88,7 +88,7 @@ services:
     environment:
       - DUMBKAN_PIN=${DUMB_PIN:-}
     healthcheck:
-      test: ["CMD-SHELL", "curl --fail http://localhost:${DUMBKAN_PORT:-3333} || exit 1"]
+      test: wget --spider -q  http://127.0.0.1:3000
       start_period: 20s
       interval: 20s
       timeout: 5s

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -30,12 +30,12 @@ services:
       - ${DUMBDO_DATA_PATH:-/opt/dumbsuite/dumbdo}:/app/data
     environment:
       - DUMBDO_PIN=${DUMB_PIN:-}
-    healthcheck:
-      test: wget --spider -q  http://127.0.0.1:3000
-      start_period: 20s
-      interval: 20s
-      timeout: 5s
-      retries: 3
+    #healthcheck:
+    #  test: wget --spider -q  http://127.0.0.1:3000
+    #  start_period: 20s
+    #  interval: 20s
+    #  timeout: 5s
+    #  retries: 3
 
   dumbdrop:
     image: dumbwareio/dumbdrop:latest
@@ -68,12 +68,12 @@ services:
       - ${DUMBPAD_DATA_PATH:-/opt/dumbsuite/dumbpad}:/app/data
     environment:
       - DUMBPAD_PIN=${DUMB_PIN:-}
-    healthcheck:
-      test: wget --spider -q  http://127.0.0.1:3000
-      start_period: 20s
-      interval: 20s
-      timeout: 5s
-      retries: 3
+    #healthcheck:
+    #  test: wget --spider -q  http://127.0.0.1:3000
+    #  start_period: 20s
+    #  interval: 20s
+    #  timeout: 5s
+    #  retries: 3
 
   dumbkan:
     image: dumbwareio/dumbkan:latest

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -2,6 +2,7 @@ services:
   dumbbudget:
     image: dumbwareio/dumbbudget:latest
     container_name: dumbbudget
+    restart: unless-stopped
     ports:
       - ${DUMB_PORT:-3000}:3000
     volumes:
@@ -11,6 +12,8 @@ services:
 
   dumbdo:
     image: dumbwareio/dumbdo:latest
+    container_name: dumbdo
+    restart: unless-stopped
     ports:
       - ${DUMB_PORT:-3000}:3000
     volumes:
@@ -20,6 +23,8 @@ services:
 
   dumbdrop:
     image: dumbwareio/dumbdrop:latest
+    container_name: dumbdrop
+    restart: unless-stopped
     ports:
       - ${DUMB_PORT:-3000}:3000
     volumes:
@@ -29,6 +34,8 @@ services:
 
   dumbpad:
     image: dumbwareio/dumbpad:latest
+    container_name: dumbpad
+    restart: unless-stopped
     ports:
       - ${DUMB_PORT:-3000}:3000
     volumes:
@@ -38,6 +45,8 @@ services:
 
   dumbkan:
     image: dumbwareio/dumbkan:latest
+    container_name: dumbkan
+    restart: unless-stopped
     ports:
       - ${DUMB_PORT:-3000}:3000
     volumes:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,47 +1,46 @@
-version: "3.8"
-
 services:
   dumbbudget:
     image: dumbwareio/dumbbudget:latest
+    container_name: dumbbudget
     ports:
-      - "YOUR_PORT_HERE:3000"
+      - ${DUMB_PORT:-3000}:3000
     volumes:
-      - /path/to/your/dumbbudget/data:/app/data
+      - ${DUMBBUDGET_DATA_PATH:-/opt/dumbsuite/dumbbudget}:/app/data
     environment:
-      - DUMBBUDGET_PIN=
+      - DUMBBUDGET_PIN=${DUMB_PIN:-}
 
   dumbdo:
     image: dumbwareio/dumbdo:latest
     ports:
-      - "YOUR_PORT_HERE:3000"
+      - ${DUMB_PORT:-3000}:3000
     volumes:
-      - /path/to/your/dumbdo/data:/app/data
+      - ${DUMBDO_DATA_PATH:-/opt/dumbsuite/dumbdo}:/app/data
     environment:
-      - DUMBDO_PIN=
+      - DUMBDO_PIN=${DUMB_PIN:-}
 
   dumbdrop:
     image: dumbwareio/dumbdrop:latest
     ports:
-      - "YOUR_PORT_HERE:3000"
+      - ${DUMB_PORT:-3000}:3000
     volumes:
-      - /path/to/your/dumbdrop/uploads:/app/uploads
+      - ${DUMBDROP_DATA_PATH:-/opt/dumbsuite/dumbdrop}:/app/data
     environment:
-      - DUMBDROP_PIN=
+      - DUMBDROP_PIN=${DUMB_PIN:-}
 
   dumbpad:
     image: dumbwareio/dumbpad:latest
     ports:
-      - "YOUR_PORT_HERE:3000"
+      - ${DUMB_PORT:-3000}:3000
     volumes:
-      - /path/to/your/dumbpad/data:/app/data
+      - ${DUMBPAD_DATA_PATH:-/opt/dumbsuite/dumbpad}:/app/data
     environment:
-      - DUMBPAD_PIN=
+      - DUMBPAD_PIN=${DUMB_PIN:-}
 
   dumbkan:
     image: dumbwareio/dumbkan:latest
     ports:
-      - "YOUR_PORT_HERE:3000"
+      - ${DUMB_PORT:-3000}:3000
     volumes:
-      - /path/to/your/dumbkan/data:/app/data
+      - ${DUMBKAN_DATA_PATH:-/opt/dumbsuite/dumbkan}:/app/data
     environment:
-      - DUMBKAN_PIN=
+      - DUMBKAN_PIN=${DUMB_PIN:-}

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -11,6 +11,12 @@ services:
       - ${DUMBBUDGET_DATA_PATH:-/opt/dumbsuite/dumbbudget}:/app/data
     environment:
       - DUMBBUDGET_PIN=${DUMB_PIN:-}
+    healthcheck:
+      test: ["CMD-SHELL", "curl --fail http://localhost:${DUMBBUDGET_PORT:-3333} || exit 1"]
+      start_period: 20s
+      interval: 20s
+      timeout: 5s
+      retries: 3
 
   dumbdo:
     image: dumbwareio/dumbdo:latest
@@ -24,6 +30,12 @@ services:
       - ${DUMBDO_DATA_PATH:-/opt/dumbsuite/dumbdo}:/app/data
     environment:
       - DUMBDO_PIN=${DUMB_PIN:-}
+    healthcheck:
+      test: ["CMD-SHELL", "curl --fail http://localhost:${DUMBDO_PORT:-3333} || exit 1"]
+      start_period: 20s
+      interval: 20s
+      timeout: 5s
+      retries: 3
 
   dumbdrop:
     image: dumbwareio/dumbdrop:latest
@@ -37,6 +49,12 @@ services:
       - ${DUMBDROP_DATA_PATH:-/opt/dumbsuite/dumbdrop}:/app/data
     environment:
       - DUMBDROP_PIN=${DUMB_PIN:-}
+    healthcheck:
+      test: ["CMD-SHELL", "curl --fail http://localhost:${DUMBDROP_PORT:-3333} || exit 1"]
+      start_period: 20s
+      interval: 20s
+      timeout: 5s
+      retries: 3
 
   dumbpad:
     image: dumbwareio/dumbpad:latest
@@ -50,6 +68,12 @@ services:
       - ${DUMBPAD_DATA_PATH:-/opt/dumbsuite/dumbpad}:/app/data
     environment:
       - DUMBPAD_PIN=${DUMB_PIN:-}
+    healthcheck:
+      test: ["CMD-SHELL", "curl --fail http://localhost:${DUMBPAD_PORT:-3333} || exit 1"]
+      start_period: 20s
+      interval: 20s
+      timeout: 5s
+      retries: 3
 
   dumbkan:
     image: dumbwareio/dumbkan:latest
@@ -63,6 +87,12 @@ services:
       - ${DUMBKAN_DATA_PATH:-/opt/dumbsuite/dumbkan}:/app/data
     environment:
       - DUMBKAN_PIN=${DUMB_PIN:-}
+    healthcheck:
+      test: ["CMD-SHELL", "curl --fail http://localhost:${DUMBKAN_PORT:-3333} || exit 1"]
+      start_period: 20s
+      interval: 20s
+      timeout: 5s
+      retries: 3
 
 networks:
   dumb-net:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -3,8 +3,10 @@ services:
     image: dumbwareio/dumbbudget:latest
     container_name: dumbbudget
     restart: unless-stopped
+    networks:
+      - dumb-net
     ports:
-      - ${DUMB_PORT:-3000}:3000
+      - ${DUMBBUDGET_PORT:-3333}:3000
     volumes:
       - ${DUMBBUDGET_DATA_PATH:-/opt/dumbsuite/dumbbudget}:/app/data
     environment:
@@ -14,8 +16,10 @@ services:
     image: dumbwareio/dumbdo:latest
     container_name: dumbdo
     restart: unless-stopped
+    networks:
+      - dumb-net
     ports:
-      - ${DUMB_PORT:-3000}:3000
+      - ${DUMBDO_PORT:-3334}:3000
     volumes:
       - ${DUMBDO_DATA_PATH:-/opt/dumbsuite/dumbdo}:/app/data
     environment:
@@ -25,8 +29,10 @@ services:
     image: dumbwareio/dumbdrop:latest
     container_name: dumbdrop
     restart: unless-stopped
+    networks:
+      - dumb-net
     ports:
-      - ${DUMB_PORT:-3000}:3000
+      - ${DUMBDROP_PORT:-3335}:3000
     volumes:
       - ${DUMBDROP_DATA_PATH:-/opt/dumbsuite/dumbdrop}:/app/data
     environment:
@@ -36,8 +42,10 @@ services:
     image: dumbwareio/dumbpad:latest
     container_name: dumbpad
     restart: unless-stopped
+    networks:
+      - dumb-net
     ports:
-      - ${DUMB_PORT:-3000}:3000
+      - ${DUMBPAD_PORT:-3336}:3000
     volumes:
       - ${DUMBPAD_DATA_PATH:-/opt/dumbsuite/dumbpad}:/app/data
     environment:
@@ -47,9 +55,15 @@ services:
     image: dumbwareio/dumbkan:latest
     container_name: dumbkan
     restart: unless-stopped
+    networks:
+      - dumb-net
     ports:
-      - ${DUMB_PORT:-3000}:3000
+      - ${DUMBKAN_PORT:-3337}:3000
     volumes:
       - ${DUMBKAN_DATA_PATH:-/opt/dumbsuite/dumbkan}:/app/data
     environment:
       - DUMBKAN_PIN=${DUMB_PIN:-}
+
+networks:
+  dumb-net:
+    name: dumb-net

--- a/env
+++ b/env
@@ -1,0 +1,7 @@
+DUMB_PORT=3000
+DUMB_PIN=1234
+DUMBBUDGET_DATA_PATH=/opt/dumbsuite/dumbbudget
+DUMBDO_DATA_PATH=/opt/dumbsuite/dumbdo
+DUMBDROP_DATA_PATH=/opt/dumbsuite/dumbdrop
+DUMBPAD_DATA_PATH=/opt/dumbsuite/dumbpad
+DUMBKAN_DATA_PATH=/opt/dumbsuite/dumbkan

--- a/env
+++ b/env
@@ -1,7 +1,16 @@
-DUMB_PORT=3000
 DUMB_PIN=1234
+
+DUMBBUDGET_PORT=3333
 DUMBBUDGET_DATA_PATH=/opt/dumbsuite/dumbbudget
+
+DUMBDO_PORT=3334
 DUMBDO_DATA_PATH=/opt/dumbsuite/dumbdo
+
+DUMBDROP_PORT=3335
 DUMBDROP_DATA_PATH=/opt/dumbsuite/dumbdrop
+
+DUMBPAD_PORT=3336
 DUMBPAD_DATA_PATH=/opt/dumbsuite/dumbpad
+
+DUMBKAN_PORT=3337
 DUMBKAN_DATA_PATH=/opt/dumbsuite/dumbkan


### PR DESCRIPTION
Modified docker-compose.yml, README.md and added env to aid V and abite with dumb deployment.

The docker-compose.yml file need not be edited by users wanting a very straight forward dumb deployment. They can copy env to .env and modify variables in there to fix their environment (eg: different ports or paths) or they can use the docker-compose.yml as a basic template and change it to their hearts contents.

As a "download and run" it operates with zero-configuration. All configuration is completely optional which I think fits with the dumb theme.